### PR TITLE
fix: patches read_centroid_spectrum function

### DIFF
--- a/tests/test_tsf.py
+++ b/tests/test_tsf.py
@@ -2,6 +2,7 @@
 import pytest
 from imzy import TSFReader, get_reader
 from koyo.system import IS_MAC
+import numpy as np
 
 from .utilities import get_tsf_data
 
@@ -81,3 +82,15 @@ def test_to_h5(path, tmp_path):
     h5_path = reader.to_hdf5(h5_temp, mzs, tol=0.5)
     assert h5_path.exists()
     assert h5_temp != h5_path
+
+
+@pytest.mark.skipif(IS_MAC, reason="Bruker reader is not supported on macOS.")
+@pytest.mark.parametrize("path", get_tsf_data())
+def test_read_centroid_spectrum(path):
+    reader = TSFReader(path)
+    for pixel in reader.pixels:
+        mzs, intensities = reader.read_centroid_spectrum(pixel)
+    assert mzs.dtype == np.float64
+    assert intensities.dtype == np.float32
+    assert pixel == reader.n_pixels - 1
+    


### PR DESCRIPTION
## Description

When spectra have `line_buffer_size` larger than 1024, the `read_centroid_spectrum()` function in the `_tsf` module loops forever as it never meets the condition for breaking.
The aim of this PR is to address such situation by modifying the actual variable that needs to be increased.

## Related Issue

No issue was reported previously

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/imzy/imzy/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/imzy/imzy/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
